### PR TITLE
Add subject field

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ Example.
 | default_schema_name        | string |          | nil                | Default schema name when the record doesn't have schema_name_key                                            |
 | schema_name_key            | string |          | `"schema_name"`    | Field for schema name                                                                                       |
 | schema                     | hash   |          | nil                | Inline schema definition. If this parameter is set, `default_schema_name` and `schema_name_key` are ignored |
+| subject_key                | string |          | nil                | Field for subject                                                                                           |
 | default_namespace          | string |          | nil                | Default schema namespace                                                                                    |
 | namespace_key              | string |          | `"namespace"`      | Field for namespace                                                                                         |
 | schema_version_key         | string |          | `"schema_version"` | Field for schema version                                                                                    |
 | exclude_schema_name_key    | bool   |          | false              | Set true to remove schema_name_key field from data                                                          |
 | exclude_namespace_key      | bool   |          | false              | Set true to remove namespace_key field from data                                                            |
 | exclude_schema_version_key | bool   |          | false              | Set true to remove schema_version_key field from data                                                       |
+| exclude_subject_key        | bool   |          | false              | Set true to remove subject_key field from data                                                              |
 
 
 ## Copyright

--- a/fluent-plugin-avro_turf.gemspec
+++ b/fluent-plugin-avro_turf.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-avro_turf"
-  spec.version = "0.1.0"
+  spec.version = "0.1.1"
   spec.authors = ["joker1007"]
   spec.email   = ["kakyoin.hierophant@gmail.com"]
 

--- a/lib/fluent/plugin/formatter_avro_turf_messaging.rb
+++ b/lib/fluent/plugin/formatter_avro_turf_messaging.rb
@@ -29,6 +29,7 @@ module Fluent
 
       config_param :default_schema_name, :string, default: nil, desc: "Default schema name when the record doesn't have schema_name_key"
       config_param :schema_name_key, :string, default: "schema_name", desc: "Field for schema name"
+      config_param :subject_key, :string, default: nil, desc: "Field for subject"
 
       config_param :schema, :hash, default: nil, desc: "Inline schema definition. If this parameter is set, `default_schema_name` and `schema_name_key` are ignored"
 
@@ -40,6 +41,7 @@ module Fluent
       config_param :exclude_schema_name_key, :bool, default: false, desc: "Set true to remove schema_name_key field from data"
       config_param :exclude_namespace_key, :bool, default: false, desc: "Set true to remove namespace_key field from data"
       config_param :exclude_schema_version_key, :bool, default: false, desc: "Set true to remove schema_version_key field from data"
+      config_param :exclude_subject_key, :bool, default: false, desc: "Set true to remove subject_key field from data"
 
       def configure(conf)
         super
@@ -70,11 +72,15 @@ module Fluent
         end
         namespace ||= @default_namespace
 
+        if @subject_key
+          subject = @exclude_subject_key ? record.delete(@subject_key) : record[@subject_key]
+        end
+
         if @schema_version_key
           schema_version = @exclude_schema_version_key ? record.delete(@schema_version_key) : record[@schema_version_key]
         end
 
-        @avro_turf.encode(record, schema_name: schema_name, namespace: namespace, version: schema_version)
+        @avro_turf.encode(record, schema_name: schema_name, namespace: namespace, subject: subject, version: schema_version)
       end
     end
   end


### PR DESCRIPTION
Add an option to specify `subject` in the plugin's configuration. This https://github.com/joker1007/fluent-plugin-avro_turf/issues/1 can be addressed by this pull request as well as by specifying subject avro-turf verifies whether schema exists in schema registry.   